### PR TITLE
Force int cast on ModelsLoader count.

### DIFF
--- a/src/Execution/ModelsLoader/CountModelsLoader.php
+++ b/src/Execution/ModelsLoader/CountModelsLoader.php
@@ -32,7 +32,7 @@ class CountModelsLoader implements ModelsLoader
          */
         $countAttributeName = Str::snake("{$relationName}_count");
 
-        $count = $model->getAttribute($countAttributeName);
+        $count = (int) $model->getAttribute($countAttributeName);
         assert(is_int($count), 'avoid runtime check in production since the return type validates this anyway');
 
         return $count;


### PR DESCRIPTION
When dealing with **legacy databases**  the count for this related model returns a string like `"88"`, not `88`.

```
comments: [Comment] @hasMany(type: PAGINATOR)
```

After upgrading to PHP 8.4 this does not work anymore. And it throws a error 

_"Nuwave\Lighthouse\Execution\ModelsLoader\CountModelsLoader::extractCount(): Return value must be of type int, string returned"_


**Changes**

Always cast to integer. Because, this count must be an integer, always.

**Breaking changes**

No.